### PR TITLE
예측리스트 구현완료

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,12 @@
 import 'package:ballkkaye_frontend/_core/style/m_theme.dart';
 import 'package:ballkkaye_frontend/ui/pages/auth/join_page/join_page.dart';
 import 'package:ballkkaye_frontend/ui/pages/auth/login_page/login_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/matchup_page/matchup_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/prediction_page/prediction_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/rainout_prediction_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/ranking_page/ranking_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/today_game_page/today_game_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/user_prediction_page/user_prediction_page.dart';
 import 'package:ballkkaye_frontend/ui/pages/holder/home/home_page.dart';
 import 'package:ballkkaye_frontend/ui/pages/holder/main_holder.dart';
 import 'package:ballkkaye_frontend/ui/pages/holder/visit_record/detail_page/visit_record_detail_page.dart';
@@ -35,6 +41,12 @@ class MyApp extends StatelessWidget {
         "/mainholder": (context) => MainHolder(),
         "/visitrecord/write": (context) => const VisitRecordWritePage(),
         "/visitrecord/detail": (context) => const VisitRecordDetailPage(),
+        "/game_center/matchup": (context) => const MatchupPage(),
+        "/game_center/prediction": (context) => const PredictionPage(),
+        "/game_center/rainout_prediction": (context) => const RainoutPredictionPage(),
+        "/game_center/ranking": (context) => const RankingPage(),
+        "/game_center/today_game": (context) => const TodayGamePage(),
+        "/game_center/user_prediction": (context) => const UserPredictionPage(),
       },
     );
   }

--- a/lib/ui/pages/holder/game_center/game_center_page.dart
+++ b/lib/ui/pages/holder/game_center/game_center_page.dart
@@ -1,3 +1,5 @@
+import 'package:ballkkaye_frontend/_core/style/m_text.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/widget/game_center_body.dart';
 import 'package:flutter/material.dart';
 
 class GameCenterPage extends StatelessWidget {
@@ -5,9 +7,18 @@ class GameCenterPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Container(
-        child: Text("예측(게임센터) 페이지"),
+    return Scaffold(
+      appBar: _appbar(),
+      body: GameCenterBody(),
+    );
+  }
+
+  AppBar _appbar() {
+    return AppBar(
+      automaticallyImplyLeading: false,
+      title: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: MText.h1('예측'),
       ),
     );
   }

--- a/lib/ui/pages/holder/game_center/matchup_page/matchup_page.dart
+++ b/lib/ui/pages/holder/game_center/matchup_page/matchup_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class MatchupPage extends StatelessWidget {
+  const MatchupPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('상대전적확인'),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/prediction_page/prediction_page.dart
+++ b/lib/ui/pages/holder/game_center/prediction_page/prediction_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class PredictionPage extends StatelessWidget {
+  const PredictionPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('승리예측'),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/rainout_prediction_page.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/rainout_prediction_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class RainoutPredictionPage extends StatelessWidget {
+  const RainoutPredictionPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('우천취소 예측'),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/ranking_page/ranking_page.dart
+++ b/lib/ui/pages/holder/game_center/ranking_page/ranking_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class RankingPage extends StatelessWidget {
+  const RankingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('팀 순위'),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/today_game_page/today_game_page.dart
+++ b/lib/ui/pages/holder/game_center/today_game_page/today_game_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class TodayGamePage extends StatelessWidget {
+  const TodayGamePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('오늘의 경기'),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/user_prediction_page/user_prediction_page.dart
+++ b/lib/ui/pages/holder/game_center/user_prediction_page/user_prediction_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class UserPredictionPage extends StatelessWidget {
+  const UserPredictionPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('나의 승부 예측'),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/widget/game_center_body.dart
+++ b/lib/ui/pages/holder/game_center/widget/game_center_body.dart
@@ -1,0 +1,82 @@
+import 'package:ballkkaye_frontend/_core/style/m_icon.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/widget/game_center_card.dart';
+import 'package:flutter/material.dart';
+
+class GameCenterBody extends StatelessWidget {
+  const GameCenterBody({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        vertical: 22,
+        horizontal: 16,
+      ),
+      child: Column(
+        children: [
+          GameCenterCard(
+              title: '오늘의 경기',
+              description: '오늘의 경기를 확인해보세요',
+              icon: MIcon.page.predictionList.todayGame,
+              onTap: () {
+                Navigator.pushNamed(context, '/game_center/today_game');
+              }),
+          SizedBox(height: 10),
+          Row(
+            children: [
+              Expanded(
+                flex: 4,
+                child: GameCenterCard(
+                    title: '승리예측',
+                    description: '볼까예의 예측을\n확인해 보세요',
+                    icon: MIcon.page.predictionList.prediction,
+                    onTap: () {
+                      Navigator.pushNamed(context, '/game_center/today_game');
+                    }),
+              ),
+              SizedBox(width: 10),
+              Expanded(
+                flex: 6,
+                child: GameCenterCard(
+                    title: '우천취소 예측',
+                    description: '',
+                    icon: MIcon.page.predictionList.rain,
+                    onTap: () {
+                      Navigator.pushNamed(context, '/game_center/rainout_prediction');
+                    }),
+              ),
+            ],
+          ),
+          SizedBox(height: 10),
+          Row(
+            children: [
+              Expanded(
+                flex: 6,
+                child: GameCenterCard(
+                    title: '나의 승부 예측',
+                    description: '오늘 경기의 승리를\n예측해 보세요',
+                    icon: MIcon.page.predictionList.userPrediction,
+                    onTap: () {
+                      Navigator.pushNamed(context, '/game_center/user_prediction');
+                    }),
+              ),
+              SizedBox(width: 10),
+              Expanded(
+                flex: 4,
+                child: GameCenterCard(
+                    title: '팀 순위',
+                    description: '실시간 팀 순위를\n확인해 보세요',
+                    icon: MIcon.page.predictionList.ranking,
+                    onTap: () {
+                      Navigator.pushNamed(context, '/game_center/ranking');
+                    }),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/widget/game_center_card.dart
+++ b/lib/ui/pages/holder/game_center/widget/game_center_card.dart
@@ -1,0 +1,69 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:flutter/material.dart';
+
+class GameCenterCard extends StatelessWidget {
+  final String title;
+  final String description;
+  final Widget icon;
+  final VoidCallback? onTap;
+
+  const GameCenterCard({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.icon,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        width: double.infinity,
+        height: 140,
+        decoration: BoxDecoration(
+          color: MColor.kBackground.normal,
+          borderRadius: BorderRadius.circular(8),
+          boxShadow: MColor.kShadow.normal,
+        ),
+        child: Padding(
+          padding: EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Container(
+                width: double.infinity,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w700,
+                        color: MColor.kLabel.normal,
+                      ),
+                    ),
+                    SizedBox(height: 8),
+                    Text(
+                      description,
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color: MColor.kLabel.neutral,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              icon,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- 오늘의경기, 승리예측, 우천취소예측, 나의승부예측, 팀순위 페이지 기본 세팅
- main.dart에 각 페이지 routes 연결
- 예측리스트 페이지 구현
- 예측리스트 페이지에서 카드 분리
- 예측리스트 페이지에서 카드리스트 분리