### PR TITLE
승리예측 화면 구현

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,12 +41,12 @@ class MyApp extends StatelessWidget {
         "/mainholder": (context) => MainHolder(),
         "/visitrecord/write": (context) => const VisitRecordWritePage(),
         "/visitrecord/detail": (context) => const VisitRecordDetailPage(),
-        "/game_center/matchup": (context) => const MatchupPage(),
-        "/game_center/prediction": (context) => const PredictionPage(),
-        "/game_center/rainout_prediction": (context) => const RainoutPredictionPage(),
-        "/game_center/ranking": (context) => const RankingPage(),
-        "/game_center/today_game": (context) => const TodayGamePage(),
-        "/game_center/user_prediction": (context) => const UserPredictionPage(),
+        "/game-center/matchup": (context) => const MatchupPage(),
+        "/game-center/prediction": (context) => const PredictionPage(),
+        "/game-center/rainout-prediction": (context) => const RainoutPredictionPage(),
+        "/game-center/ranking": (context) => const RankingPage(),
+        "/game-center/today-game": (context) => const TodayGamePage(),
+        "/game-center/user-prediction": (context) => const UserPredictionPage(),
       },
     );
   }

--- a/lib/ui/pages/holder/game_center/prediction_page/prediction_page.dart
+++ b/lib/ui/pages/holder/game_center/prediction_page/prediction_page.dart
@@ -1,3 +1,5 @@
+import 'package:ballkkaye_frontend/_core/style/m_text.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/prediction_page/widget/prediction_body.dart';
 import 'package:flutter/material.dart';
 
 class PredictionPage extends StatelessWidget {
@@ -5,9 +7,18 @@ class PredictionPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text('승리예측'),
+    return Scaffold(
+      appBar: _appbar(),
+      body: PredictionBody(),
+    );
+  }
+
+  AppBar _appbar() {
+    return AppBar(
+      centerTitle: true,
+      title: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: MText.h1('승리예측'),
       ),
     );
   }

--- a/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_bar_graph_title.dart
+++ b/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_bar_graph_title.dart
@@ -1,0 +1,56 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:flutter/material.dart';
+
+class PredictionGraphTitle extends StatelessWidget {
+  final String title;
+  final String? totalScore;
+  final double? totalScoreValue;
+  final bool showTotalLabel;
+
+  const PredictionGraphTitle({
+    super.key,
+    required this.title,
+    this.totalScore,
+    this.totalScoreValue,
+    this.showTotalLabel = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          title,
+          style: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+            color: MColor.kLabel.normal,
+          ),
+        ),
+        if (showTotalLabel && totalScore != null && totalScoreValue != null)
+          Row(
+            children: [
+              Text(
+                totalScore!,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w400,
+                  color: MColor.kLabel.normal,
+                ),
+              ),
+              SizedBox(width: 4),
+              Text(
+                totalScoreValue!.toStringAsFixed(1),
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  color: MColor.kLabel.normal,
+                ),
+              ),
+            ],
+          ),
+      ],
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_body.dart
+++ b/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_body.dart
@@ -1,0 +1,41 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/_core/style/m_text.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/prediction_page/widget/prediction_card.dart';
+import 'package:flutter/material.dart';
+
+class PredictionBody extends StatelessWidget {
+  const PredictionBody({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(children: [
+      Padding(
+        padding: EdgeInsets.only(
+          top: 22,
+          left: 16,
+          right: 16,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            MText.h2(
+              '오늘 승리 예측',
+              color: MColor.kLabel.normal,
+            ),
+            SizedBox(height: 12),
+            Column(
+              children: [
+                // 카드
+                PredictionCard(),
+                PredictionCard(),
+                PredictionCard(),
+              ],
+            ),
+          ],
+        ),
+      ),
+    ]);
+  }
+}

--- a/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_card.dart
+++ b/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_card.dart
@@ -1,0 +1,248 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/_core/style/m_text.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/prediction_page/widget/prediction_bar_graph_title.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/prediction_page/widget/prediction_graph_value.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/prediction_page/widget/prediction_player_image.dart';
+import 'package:flutter/material.dart';
+
+class PredictionCard extends StatelessWidget {
+  const PredictionCard({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          padding: EdgeInsets.all(12.0),
+          decoration: BoxDecoration(
+            color: MColor.kBackground.normal,
+            borderRadius: BorderRadius.circular(8),
+            boxShadow: MColor.kShadow.normal,
+          ),
+          child: Column(
+            children: [
+              // 선수프로필, 상대전적확인버튼
+              Row(
+                children: [
+                  Expanded(
+                    // 윗영역
+                    child: Column(
+                      children: [
+                        // 팀명라벨, 선수명
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            // 팀명 라벨
+                            Container(
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(4),
+                                color: MColor.kPrimary.strong,
+                              ),
+                              child: Padding(
+                                padding: EdgeInsets.symmetric(
+                                  horizontal: 4,
+                                  vertical: 2,
+                                ),
+                                child: MText.label2_7(
+                                  '팀명',
+                                  color: MColor.kLabel.white,
+                                ),
+                              ),
+                            ),
+                            SizedBox(width: 2),
+                            // 선수명
+                            Text(
+                              '선수명',
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w400,
+                                color: MColor.kLabel.normal,
+                              ),
+                            ),
+                          ],
+                        ),
+                        // 여백
+                        SizedBox(height: 4),
+                        // 선수 프로필사진
+                        Row(
+                          children: [
+                            Expanded(
+                              child: AspectRatio(
+                                aspectRatio: 5 / 7,
+                                child: Container(
+                                  decoration: BoxDecoration(
+                                    color: MColor.kFill.normal,
+                                    borderRadius: BorderRadius.circular(8),
+                                  ),
+                                  // TODO: 나중에 통신 연결 시 null자리에 imageUrl
+                                  child: PredictionPlayerImage(null),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        // 여백
+                        SizedBox(height: 10),
+                        // 버튼
+                        AspectRatio(
+                          aspectRatio: 131 / 34,
+                          child: SizedBox(
+                            width: double.infinity,
+                            child: OutlinedButton(
+                              onPressed: () {
+                                Navigator.pushNamed(context, '/game-center/matchup');
+                              },
+                              style: OutlinedButton.styleFrom(
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(4),
+                                ),
+                                foregroundColor: MColor.kPrimary.normal,
+                                side: BorderSide(color: MColor.kPrimary.strong),
+                              ),
+                              child: MText.button5_7(
+                                '상대 전적 확인',
+                                color: MColor.kPrimary.strong,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  SizedBox(width: 10),
+                  Text(
+                    'VS',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      color: MColor.kLabel.neutral,
+                    ),
+                  ),
+                  SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      children: [
+                        // 팀명라벨, 선수명
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            // 팀명 라벨
+                            Container(
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(4),
+                                color: MColor.kPrimary.strong,
+                              ),
+                              child: Padding(
+                                padding: EdgeInsets.symmetric(
+                                  horizontal: 4,
+                                  vertical: 2,
+                                ),
+                                child: MText.label2_7(
+                                  '팀명',
+                                  color: MColor.kLabel.white,
+                                ),
+                              ),
+                            ),
+                            SizedBox(width: 2),
+                            // 선수명
+                            Text(
+                              '선수명',
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w400,
+                                color: MColor.kLabel.normal,
+                              ),
+                            ),
+                          ],
+                        ),
+                        // 여백
+                        SizedBox(height: 4),
+                        // 선수 프로필사진
+                        Row(
+                          children: [
+                            Expanded(
+                              child: AspectRatio(
+                                aspectRatio: 5 / 7,
+                                child: Container(
+                                  decoration: BoxDecoration(
+                                    color: MColor.kFill.normal,
+                                    borderRadius: BorderRadius.circular(8),
+                                  ),
+                                  // TODO: 나중에 통신 연결 시 null자리에 imageUrl
+                                  child: PredictionPlayerImage(null),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        // 여백
+                        SizedBox(height: 10),
+                        // 버튼
+                        AspectRatio(
+                          aspectRatio: 131 / 34,
+                          child: SizedBox(
+                            width: double.infinity,
+                            child: OutlinedButton(
+                              onPressed: () {
+                                Navigator.pushNamed(context, '/game-center/matchup');
+                              },
+                              style: OutlinedButton.styleFrom(
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(4),
+                                ),
+                                foregroundColor: MColor.kPrimary.normal,
+                                side: BorderSide(color: MColor.kPrimary.strong),
+                              ),
+                              child: MText.button5_7(
+                                '상대 전적 확인',
+                                color: MColor.kPrimary.strong,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(height: 14),
+              // 예상득점, 승리확률
+              Column(
+                children: [
+                  Column(
+                    children: [
+                      PredictionGraphTitle(
+                        title: '예상득점',
+                        showTotalLabel: true,
+                        totalScore: '양팀 득점 합계',
+                        totalScoreValue: 7.7,
+                      ),
+                      SizedBox(height: 6),
+                      PredictionGraphValue(leftScore: 3.2, rightScore: 4.5),
+                    ],
+                  ),
+                  SizedBox(height: 12),
+                  Column(
+                    children: [
+                      PredictionGraphTitle(
+                        title: '승리확률',
+                        showTotalLabel: false,
+                      ),
+                      SizedBox(height: 6),
+                      PredictionGraphValue(leftScore: 42.8, rightScore: 57.2),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        SizedBox(height: 14),
+      ],
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_graph_value.dart
+++ b/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_graph_value.dart
@@ -1,0 +1,16 @@
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/prediction_page/widget/prediction_praph_value_state.dart';
+import 'package:flutter/material.dart';
+
+class PredictionGraphValue extends StatefulWidget {
+  final double leftScore;
+  final double rightScore;
+
+  const PredictionGraphValue({
+    super.key,
+    required this.leftScore,
+    required this.rightScore,
+  });
+
+  @override
+  State<PredictionGraphValue> createState() => PredictionGraphValueState();
+}

--- a/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_player_image.dart
+++ b/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_player_image.dart
@@ -1,0 +1,22 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:flutter/material.dart';
+
+Widget PredictionPlayerImage(String? imageUrl) {
+  if (imageUrl == null || imageUrl.isEmpty) {
+    return Center(
+      child: Text(
+        '이미지 준비중',
+        style: TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.w600,
+          color: MColor.kLabel.alternative,
+        ),
+      ),
+    );
+  } else {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(8),
+      child: Image.network(imageUrl, fit: BoxFit.cover),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_praph_value_state.dart
+++ b/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_praph_value_state.dart
@@ -1,0 +1,99 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/prediction_page/widget/prediction_graph_value.dart';
+import 'package:flutter/material.dart';
+
+class PredictionGraphValueState extends State<PredictionGraphValue> with SingleTickerProviderStateMixin {
+  late double leftRatio;
+  late double rightRatio;
+  late bool isLeftHigher;
+
+  @override
+  void initState() {
+    super.initState();
+    calculateRatio();
+  }
+
+  void calculateRatio() {
+    final total = widget.leftScore + widget.rightScore;
+    leftRatio = total == 0 ? 0.5 : widget.leftScore / total;
+    rightRatio = total == 0 ? 0.5 : widget.rightScore / total;
+    isLeftHigher = widget.leftScore > widget.rightScore;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+
+        return Container(
+          height: 24,
+          decoration: BoxDecoration(
+            color: Colors.grey.shade200,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Stack(
+            children: [
+              // 왼쪽 바
+              AnimatedContainer(
+                duration: Duration(milliseconds: 800),
+                width: width * leftRatio,
+                decoration: BoxDecoration(
+                  color: isLeftHigher ? MColor.kPrimary.alternative : MColor.kFill.normal,
+                  borderRadius: BorderRadius.horizontal(
+                    left: Radius.circular(8),
+                    right: Radius.circular(isLeftHigher ? 8 : 0),
+                  ),
+                ),
+              ),
+
+              // 오른쪽 바
+              Align(
+                alignment: Alignment.centerRight,
+                child: AnimatedContainer(
+                  duration: Duration(milliseconds: 800),
+                  width: width * rightRatio,
+                  decoration: BoxDecoration(
+                    color: !isLeftHigher ? MColor.kPrimary.alternative : MColor.kFill.normal,
+                    borderRadius: BorderRadius.horizontal(
+                      right: Radius.circular(8),
+                      left: Radius.circular(!isLeftHigher ? 8 : 0),
+                    ),
+                  ),
+                ),
+              ),
+
+              // 텍스트 레이어
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Center(
+                      child: Text(
+                        widget.leftScore.toStringAsFixed(1),
+                        style: TextStyle(
+                          color: isLeftHigher ? MColor.kLabel.white : MColor.kLabel.alternative,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                    Center(
+                      child: Text(
+                        widget.rightScore.toStringAsFixed(1),
+                        style: TextStyle(
+                          color: !isLeftHigher ? MColor.kLabel.white : MColor.kLabel.alternative,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/widget/game_center_body.dart
+++ b/lib/ui/pages/holder/game_center/widget/game_center_body.dart
@@ -21,7 +21,7 @@ class GameCenterBody extends StatelessWidget {
               description: '오늘의 경기를 확인해보세요',
               icon: MIcon.page.predictionList.todayGame,
               onTap: () {
-                Navigator.pushNamed(context, '/game_center/today_game');
+                Navigator.pushNamed(context, '/game-center/today-game');
               }),
           SizedBox(height: 10),
           Row(
@@ -33,7 +33,7 @@ class GameCenterBody extends StatelessWidget {
                     description: '볼까예의 예측을\n확인해 보세요',
                     icon: MIcon.page.predictionList.prediction,
                     onTap: () {
-                      Navigator.pushNamed(context, '/game_center/prediction');
+                      Navigator.pushNamed(context, '/game-center/prediction');
                     }),
               ),
               SizedBox(width: 10),
@@ -44,7 +44,7 @@ class GameCenterBody extends StatelessWidget {
                     description: '',
                     icon: MIcon.page.predictionList.rain,
                     onTap: () {
-                      Navigator.pushNamed(context, '/game_center/rainout_prediction');
+                      Navigator.pushNamed(context, '/game-center/rainout-prediction');
                     }),
               ),
             ],
@@ -59,7 +59,7 @@ class GameCenterBody extends StatelessWidget {
                     description: '오늘 경기의 승리를\n예측해 보세요',
                     icon: MIcon.page.predictionList.userPrediction,
                     onTap: () {
-                      Navigator.pushNamed(context, '/game_center/user_prediction');
+                      Navigator.pushNamed(context, '/game-center/user-prediction');
                     }),
               ),
               SizedBox(width: 10),
@@ -70,7 +70,7 @@ class GameCenterBody extends StatelessWidget {
                     description: '실시간 팀 순위를\n확인해 보세요',
                     icon: MIcon.page.predictionList.ranking,
                     onTap: () {
-                      Navigator.pushNamed(context, '/game_center/ranking');
+                      Navigator.pushNamed(context, '/game-center/ranking');
                     }),
               ),
             ],


### PR DESCRIPTION
- main.dart routes 주소 수정
- 승리예측 화면 구현
- prediction_bar_graph_title : 그래프 상단 타이틀 및 텍스트 컴포넌트 분리
- prediction_praph_value : 그래프 컴포넌트 분리
- prediction_praph_value_state : 그래프 안에 들어가는 값에 따른 그래프 길이 변화 구현
- prediction_player_image : 선수 이미지 컴포넌트 분리
- prediction_card : 승리예측 카드 컴포넌트 분리