### PR TITLE
상대전적확인 구현

### DIFF
--- a/lib/ui/pages/holder/game_center/matchup_page/matchup_page.dart
+++ b/lib/ui/pages/holder/game_center/matchup_page/matchup_page.dart
@@ -1,3 +1,5 @@
+import 'package:ballkkaye_frontend/_core/style/m_text.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/matchup_page/widget/matchup_body.dart';
 import 'package:flutter/material.dart';
 
 class MatchupPage extends StatelessWidget {
@@ -5,9 +7,18 @@ class MatchupPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text('상대전적확인'),
+    return Scaffold(
+      appBar: _appbar(),
+      body: MatchupBody(),
+    );
+  }
+
+  AppBar _appbar() {
+    return AppBar(
+      centerTitle: true,
+      title: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: MText.h1('상대전적확인'),
       ),
     );
   }

--- a/lib/ui/pages/holder/game_center/matchup_page/widget/matchup_body.dart
+++ b/lib/ui/pages/holder/game_center/matchup_page/widget/matchup_body.dart
@@ -1,0 +1,49 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/_core/style/m_text.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/matchup_page/widget/matchup_chart.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/matchup_page/widget/matchup_starting_pitcher.dart';
+import 'package:flutter/material.dart';
+
+class MatchupBody extends StatelessWidget {
+  const MatchupBody({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(
+        top: 22,
+        left: 16,
+        right: 16,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          MText.h2('상태팀 선발 투수'),
+          SizedBox(height: 12),
+          MatchupStartingPitcher(),
+          SizedBox(height: 22),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  color: MColor.kPrimary.strong,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                padding: EdgeInsets.symmetric(
+                  horizontal: 6,
+                  vertical: 4,
+                ),
+                child: MText.label1_6('2025 상대 전적', color: MColor.kLabel.white),
+              ),
+              SizedBox(height: 6),
+              MatchupChart(),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/matchup_page/widget/matchup_chart.dart
+++ b/lib/ui/pages/holder/game_center/matchup_page/widget/matchup_chart.dart
@@ -1,0 +1,340 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:flutter/material.dart';
+
+class MatchupChart extends StatelessWidget {
+  const MatchupChart({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: MColor.kLine.normal,
+            width: 1,
+          ),
+          borderRadius: BorderRadius.circular(12), // 여기도 꼭 설정
+        ),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            double parentWidth = constraints.maxWidth;
+            double childMaxWidth = parentWidth * 0.14;
+            double childMinWidth = parentWidth * 0.12;
+            return Column(
+              children: [
+                MatchupChartHead(
+                  childMinWidth: childMinWidth,
+                  childMaxWidth: childMaxWidth,
+                ),
+                MatchupChartColumnList(
+                  childMinWidth: childMinWidth,
+                  childMaxWidth: childMaxWidth,
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+// 차트 헤더
+class MatchupChartHead extends StatelessWidget {
+  const MatchupChartHead({
+    super.key,
+    required this.childMinWidth,
+    required this.childMaxWidth,
+  });
+
+  final double childMinWidth;
+  final double childMaxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: MColor.kFill.normal,
+      child: Row(
+        children: [
+          MatchupBoldRow(
+            title: '타순',
+            childWidth: childMinWidth,
+          ),
+          MatchupBoldRow(
+            title: '선수명',
+            childWidth: childMaxWidth,
+          ),
+          MatchupBoldRow(
+            title: '포지션',
+            childWidth: childMaxWidth,
+          ),
+          MatchupBoldRow(
+            title: '타수',
+            childWidth: childMinWidth,
+          ),
+          MatchupBoldRow(
+            title: '안타',
+            childWidth: childMinWidth,
+          ),
+          MatchupBoldRow(
+            title: '타율',
+            childWidth: childMinWidth,
+          ),
+          MatchupBoldRow(
+            title: 'OPS',
+            childWidth: childMinWidth,
+          ),
+          MatchupBoldRow(
+            title: '예측',
+            childWidth: childMinWidth,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// 차트 컬럼 리스트
+class MatchupChartColumnList extends StatelessWidget {
+  const MatchupChartColumnList({
+    super.key,
+    required this.childMinWidth,
+    required this.childMaxWidth,
+  });
+
+  final double childMinWidth;
+  final double childMaxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // TODO: 통신 받을 때 for문 돌리기
+        MatchupChartColumn(
+          childMinWidth: childMinWidth,
+          childMaxWidth: childMaxWidth,
+        ),
+        MatchupChartColumn(
+          childMinWidth: childMinWidth,
+          childMaxWidth: childMaxWidth,
+        ),
+        MatchupChartColumn(
+          childMinWidth: childMinWidth,
+          childMaxWidth: childMaxWidth,
+        ),
+        MatchupChartColumn(
+          childMinWidth: childMinWidth,
+          childMaxWidth: childMaxWidth,
+        ),
+        MatchupChartColumn(
+          childMinWidth: childMinWidth,
+          childMaxWidth: childMaxWidth,
+        ),
+        MatchupChartColumn(
+          childMinWidth: childMinWidth,
+          childMaxWidth: childMaxWidth,
+        ),
+        MatchupChartColumn(
+          childMinWidth: childMinWidth,
+          childMaxWidth: childMaxWidth,
+        ),
+        MatchupChartColumn(
+          childMinWidth: childMinWidth,
+          childMaxWidth: childMaxWidth,
+        ),
+        MatchupChartColumn(
+          childMinWidth: childMinWidth,
+          childMaxWidth: childMaxWidth,
+        ),
+        // TODO: 마지막행은 border bottom 없음
+        MatchChartLastColumn(
+          childMinWidth: childMinWidth,
+          childMaxWidth: childMaxWidth,
+        ),
+      ],
+    );
+  }
+}
+
+// 마지막 컬럼
+class MatchChartLastColumn extends StatelessWidget {
+  const MatchChartLastColumn({
+    super.key,
+    required this.childMinWidth,
+    required this.childMaxWidth,
+  });
+
+  final double childMinWidth;
+  final double childMaxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide.none,
+        ),
+      ),
+      child: Row(
+        children: [
+          MatchupNormalRow(
+            childWidth: childMinWidth,
+            title: '1번',
+          ),
+          MatchupBoldRow(
+            childWidth: childMaxWidth,
+            title: '손호영',
+          ),
+          MatchupNormalRow(
+            childWidth: childMaxWidth,
+            title: '2루수',
+          ),
+          MatchupNormalRow(
+            childWidth: childMinWidth,
+            title: '3타수',
+          ),
+          MatchupNormalRow(
+            childWidth: childMinWidth,
+            title: '0안타',
+          ),
+          MatchupNormalRow(
+            childWidth: childMinWidth,
+            title: '0.000',
+          ),
+          MatchupNormalRow(
+            childWidth: childMinWidth,
+            title: '0.000',
+          ),
+          MatchupNormalRow(
+            childWidth: childMinWidth,
+            title: '12%',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// 컬럼
+class MatchupChartColumn extends StatelessWidget {
+  final double childMinWidth;
+  final double childMaxWidth;
+
+  const MatchupChartColumn({
+    super.key,
+    required this.childMinWidth,
+    required this.childMaxWidth,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: MColor.kLine.normal),
+        ),
+      ),
+      child: Row(
+        children: [
+          MatchupNormalRow(
+            childWidth: childMinWidth,
+            title: '1번',
+          ),
+          MatchupBoldRow(
+            childWidth: childMaxWidth,
+            title: '손호영',
+          ),
+          MatchupNormalRow(
+            childWidth: childMaxWidth,
+            title: '2루수',
+          ),
+          MatchupNormalRow(
+            childWidth: childMinWidth,
+            title: '3타수',
+          ),
+          MatchupNormalRow(
+            childWidth: childMinWidth,
+            title: '0안타',
+          ),
+          MatchupNormalRow(
+            childWidth: childMinWidth,
+            title: '0.000',
+          ),
+          MatchupNormalRow(
+            childWidth: childMinWidth,
+            title: '0.000',
+          ),
+          MatchupNormalRow(
+            childWidth: childMinWidth,
+            title: '12%',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// 얇은 글씨체 로우
+class MatchupNormalRow extends StatelessWidget {
+  final double childWidth;
+  final String title;
+
+  const MatchupNormalRow({
+    super.key,
+    required this.childWidth,
+    required this.title,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: childWidth,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Text(
+          textAlign: TextAlign.center,
+          title,
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w400,
+            color: MColor.kLabel.normal,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// 두꺼운 글씨체 로우
+class MatchupBoldRow extends StatelessWidget {
+  final double childWidth;
+  final String title;
+
+  const MatchupBoldRow({
+    super.key,
+    required this.childWidth,
+    required this.title,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: childWidth,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Text(
+          textAlign: TextAlign.center,
+          title,
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            color: MColor.kLabel.normal,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/matchup_page/widget/matchup_player_image.dart
+++ b/lib/ui/pages/holder/game_center/matchup_page/widget/matchup_player_image.dart
@@ -1,0 +1,22 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:flutter/material.dart';
+
+Widget MatchupPlayerImage(String? imageUrl) {
+  if (imageUrl == null || imageUrl.isEmpty) {
+    return Center(
+      child: Text(
+        '이미지 준비중',
+        style: TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.w600,
+          color: MColor.kLabel.alternative,
+        ),
+      ),
+    );
+  } else {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(8),
+      child: Image.network(imageUrl, fit: BoxFit.cover),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/matchup_page/widget/matchup_player_stat_list.dart
+++ b/lib/ui/pages/holder/game_center/matchup_page/widget/matchup_player_stat_list.dart
@@ -1,0 +1,111 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:flutter/material.dart';
+
+class MatchupPlayerStatList extends StatelessWidget {
+  const MatchupPlayerStatList({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            MatchupStatTitle(
+              title: 'ERA',
+            ),
+            MatchupStatValue(
+              value: 3.84,
+            ),
+          ],
+        ),
+        Row(
+          children: [
+            MatchupStatTitle(
+              title: '경기',
+            ),
+            MatchupStatValue(
+              value: 14,
+            ),
+          ],
+        ),
+        Row(
+          children: [
+            MatchupStatTitle(
+              title: '결과',
+            ),
+            MatchupStatValue(
+              value: '4승 1패 2무',
+            ),
+          ],
+        ),
+        Row(
+          children: [
+            MatchupStatTitle(
+              title: 'QS',
+            ),
+            MatchupStatValue(
+              value: 6,
+            ),
+          ],
+        ),
+        Row(
+          children: [
+            MatchupStatTitle(
+              title: 'WHIP',
+            ),
+            MatchupStatValue(
+              value: 1.32,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+// 값 (3.84)
+class MatchupStatValue extends StatelessWidget {
+  final dynamic value;
+
+  const MatchupStatValue({
+    super.key,
+    this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      '${value}',
+      style: TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.w400,
+        color: MColor.kLabel.normal,
+      ),
+    );
+  }
+}
+
+// 타이틀 (ERA)
+class MatchupStatTitle extends StatelessWidget {
+  final String title;
+
+  const MatchupStatTitle({
+    super.key,
+    required this.title,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      '${title} : ',
+      style: TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.w400,
+        color: MColor.kLabel.normal,
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/matchup_page/widget/matchup_starting_pitcher.dart
+++ b/lib/ui/pages/holder/game_center/matchup_page/widget/matchup_starting_pitcher.dart
@@ -1,0 +1,61 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/matchup_page/widget/matchup_player_image.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/matchup_page/widget/matchup_player_stat_list.dart';
+import 'package:flutter/material.dart';
+
+class MatchupStartingPitcher extends StatelessWidget {
+  const MatchupStartingPitcher({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final imageWidth = width * (120 / 328);
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(
+                width: imageWidth,
+                child: AspectRatio(
+                  aspectRatio: 5 / 7,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: MColor.kFill.normal,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: MatchupPlayerImage(null),
+                  ),
+                ),
+              ),
+              SizedBox(width: 12), // 간격
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '선수명',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w600,
+                        color: MColor.kLabel.normal,
+                      ),
+                    ),
+                    SizedBox(height: 2),
+                    MatchupPlayerStatList(),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
- 상대전적확인 페이지 구현
- matchup_player_image : 선수 이미지 컴포넌트로 분리
- matchup_starting_pitcher : 상대팀 선발투수 이미지 및 텍스트 컴포넌트로 분리
- matchup_player_stat_list : 상단의 선수명 아래 선수 스탯 컴포넌트로 분리
- matchup_chart : 2025 상대전적 차트표 컴포넌트로 분리, 차트 안에 있는 내용의 컴포넌트는 따로 분리해서 파일로 만들지 않고 해당 페이지 내 가장 아래에 있습니다.