### PR TITLE
우천취소예측 화면 구현

### DIFF
--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/rainout_prediction_page.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/rainout_prediction_page.dart
@@ -1,14 +1,26 @@
+import 'package:ballkkaye_frontend/_core/style/m_text.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_body.dart';
 import 'package:flutter/material.dart';
 
 class RainoutPredictionPage extends StatelessWidget {
-  const RainoutPredictionPage({super.key});
+  const RainoutPredictionPage({
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text('우천취소 예측'),
-      ),
+    return Scaffold(
+      appBar: _appbar(),
+      body: RainoutPredictionBody(),
+    );
+  }
+
+  AppBar _appbar() {
+    return AppBar(
+      centerTitle: true,
+      title: MText.h1('우천취소예측'),
+      backgroundColor: Colors.white,
+      surfaceTintColor: Colors.white,
     );
   }
 }

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_body.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_body.dart
@@ -1,0 +1,33 @@
+import 'package:ballkkaye_frontend/_core/style/m_text.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_card.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_stadium_dropdown.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionBody extends StatelessWidget {
+  const RainoutPredictionBody({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 22, left: 16, right: 16),
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                MText.h2('현재 날씨'),
+                RainoutPredictionStadiumDropdown(),
+              ],
+            ),
+            SizedBox(height: 12),
+            RainoutPredictionCard(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_card.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_card.dart
@@ -1,0 +1,35 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rain_value.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_report.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_weather_head.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_weather_list.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionCard extends StatelessWidget {
+  const RainoutPredictionCard({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(vertical: 22, horizontal: 12),
+      decoration: BoxDecoration(
+        boxShadow: MColor.kShadow.normal,
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        children: [
+          RainoutPredictionWeatherHead(),
+          SizedBox(height: 20),
+          RainoutPredictionWeatherList(),
+          SizedBox(height: 20),
+          RainoutPredictionRainValue(),
+          SizedBox(height: 20),
+          RainoutPredictionReport(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_humidity.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_humidity.dart
@@ -1,0 +1,27 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/_core/style/m_icon.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionHumidity extends StatelessWidget {
+  const RainoutPredictionHumidity({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        MIcon.page.rainout.bHumidity,
+        SizedBox(height: 6),
+        Text(
+          '습도 73%',
+          style: TextStyle(
+            color: MColor.kLabel.normal,
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_keyword.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_keyword.dart
@@ -1,0 +1,27 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/_core/style/m_icon.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionKeyword extends StatelessWidget {
+  const RainoutPredictionKeyword({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        MIcon.page.rainout.bSunny,
+        SizedBox(height: 6),
+        Text(
+          '맑음',
+          style: TextStyle(
+            color: MColor.kLabel.normal,
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rain_per.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rain_per.dart
@@ -1,0 +1,43 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rain_per_box.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionRainPer extends StatelessWidget {
+  const RainoutPredictionRainPer({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '확률 %',
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w400,
+            color: MColor.kLabel.normal,
+          ),
+        ),
+        SizedBox(
+          height: 25,
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: List.generate(24, (index) {
+                return Row(
+                  children: [
+                    RainoutPredictionRainPerBox(value: index == 3 ? 60 : 0),
+                    if (index != 23) const SizedBox(width: 2),
+                  ],
+                );
+              }),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rain_per_box.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rain_per_box.dart
@@ -1,0 +1,29 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionRainPerBox extends StatelessWidget {
+  final int value;
+
+  const RainoutPredictionRainPerBox({
+    super.key,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 34,
+      height: 24,
+      color: value == 0 ? MColor.kFill.normal : Color(0x664EE1BB),
+      alignment: Alignment.center,
+      child: Text(
+        '${value}%',
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          color: value == 0 ? MColor.kLabel.alternative : MColor.kLabel.normal,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rain_value.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rain_value.dart
@@ -1,0 +1,35 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rain_per.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rainfall.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionRainValue extends StatelessWidget {
+  const RainoutPredictionRainValue({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '강수',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+            color: MColor.kLabel.normal,
+          ),
+        ),
+        SizedBox(height: 8),
+        Column(
+          children: [
+            RainoutPredictionRainPer(),
+            SizedBox(height: 8),
+            RainoutPredictionRainfall(),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rainfall.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rainfall.dart
@@ -21,7 +21,7 @@ class RainoutPredictionRainfall extends StatelessWidget {
           ),
         ),
         SizedBox(
-          height: 25,
+          height: 50,
           child: SingleChildScrollView(
             scrollDirection: Axis.horizontal,
             child: Row(
@@ -29,7 +29,10 @@ class RainoutPredictionRainfall extends StatelessWidget {
               children: List.generate(24, (index) {
                 return Row(
                   children: [
-                    RainoutPredictionRainfallBox(value: index == 3 ? 1 : 0),
+                    RainoutPredictionRainfallBox(
+                      value: index == 3 ? 1 : 0,
+                      hour: index.toString().padLeft(2, '0'),
+                    ),
                     if (index != 23) const SizedBox(width: 2),
                   ],
                 );

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rainfall.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rainfall.dart
@@ -1,0 +1,43 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rainfall_box.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionRainfall extends StatelessWidget {
+  const RainoutPredictionRainfall({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '강수량 mm',
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w400,
+            color: MColor.kLabel.normal,
+          ),
+        ),
+        SizedBox(
+          height: 25,
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: List.generate(24, (index) {
+                return Row(
+                  children: [
+                    RainoutPredictionRainfallBox(value: index == 3 ? 1 : 0),
+                    if (index != 23) const SizedBox(width: 2),
+                  ],
+                );
+              }),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rainfall_box.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rainfall_box.dart
@@ -1,0 +1,29 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionRainfallBox extends StatelessWidget {
+  final int value;
+
+  const RainoutPredictionRainfallBox({
+    super.key,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 34,
+      height: 24,
+      color: value == 0 ? MColor.kFill.normal : Color(0x664EE1BB),
+      alignment: Alignment.center,
+      child: Text(
+        '$value',
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          color: value == 0 ? MColor.kLabel.alternative : MColor.kLabel.normal,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rainfall_box.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_rainfall_box.dart
@@ -3,27 +3,46 @@ import 'package:flutter/material.dart';
 
 class RainoutPredictionRainfallBox extends StatelessWidget {
   final int value;
+  final String hour;
 
   const RainoutPredictionRainfallBox({
     super.key,
     required this.value,
+    required this.hour,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: 34,
-      height: 24,
-      color: value == 0 ? MColor.kFill.normal : Color(0x664EE1BB),
-      alignment: Alignment.center,
-      child: Text(
-        '$value',
-        style: TextStyle(
-          fontSize: 11,
-          fontWeight: FontWeight.w600,
-          color: value == 0 ? MColor.kLabel.alternative : MColor.kLabel.normal,
+    return Column(
+      children: [
+        Container(
+          width: 34,
+          height: 24,
+          color: value == 0 ? MColor.kFill.normal : Color(0x664EE1BB),
+          alignment: Alignment.center,
+          child: Text(
+            '$value',
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: value == 0 ? MColor.kLabel.alternative : MColor.kLabel.normal,
+            ),
+          ),
         ),
-      ),
+        Container(
+          width: 34,
+          height: 24,
+          alignment: Alignment.center,
+          child: Text(
+            '${hour}시',
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: MColor.kLabel.normal,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_report.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_report.dart
@@ -1,0 +1,28 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_report_label.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionReport extends StatelessWidget {
+  const RainoutPredictionReport({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '우천취소 예측 리포트',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+            color: MColor.kLabel.normal,
+          ),
+        ),
+        SizedBox(height: 10),
+        RainoutPredictionReportLabel(),
+      ],
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_report_label.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_report_label.dart
@@ -1,0 +1,39 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/_core/style/m_icon.dart';
+import 'package:ballkkaye_frontend/_core/style/m_text.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionReportLabel extends StatelessWidget {
+  const RainoutPredictionReportLabel({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Row(
+        children: [
+          Container(
+            child: MIcon.page.rainout.sRain,
+          ),
+          SizedBox(width: 6),
+          Container(
+            padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            clipBehavior: Clip.antiAlias,
+            decoration: ShapeDecoration(
+              color: Color(0x19FF4747),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(20),
+              ),
+            ),
+            child: MText.label1_5(
+              '우천취소 가능성 높음',
+              color: MColor.kStatus.negative,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_stadium_dropdown.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_stadium_dropdown.dart
@@ -1,0 +1,61 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/_core/style/m_text.dart';
+import 'package:dropdown_button2/dropdown_button2.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionStadiumDropdown extends StatelessWidget {
+  const RainoutPredictionStadiumDropdown({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final List<String> stadiums = [
+      '경기장선택',
+      '잠실야구장',
+      '고척스카이돔',
+      '인천SSG랜더스필드',
+      '수원KT위즈파크',
+      '광주기아챔피언스필드',
+      '대구삼성라이온즈파크',
+      '사직야구장',
+      '창원NC파크',
+      '대전이글스파크',
+    ];
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: MColor.kLine.normal),
+        borderRadius: BorderRadius.circular(50),
+      ),
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton2<String>(
+          isExpanded: true,
+          value: stadiums.first,
+          onChanged: (_) {},
+          items: stadiums.map((item) {
+            return DropdownMenuItem<String>(
+              value: item,
+              child: MText.button4_4(
+                item,
+                color: MColor.kLabel.alternative,
+              ),
+            );
+          }).toList(),
+          buttonStyleData: ButtonStyleData(
+            height: 29,
+            width: 120,
+            padding: EdgeInsets.symmetric(horizontal: 10),
+            overlayColor: MaterialStateProperty.all(Colors.transparent),
+          ),
+          dropdownStyleData: DropdownStyleData(
+            width: 180,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              color: Colors.white,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_weather_head.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_weather_head.dart
@@ -1,0 +1,42 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionWeatherHead extends StatelessWidget {
+  const RainoutPredictionWeatherHead({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          '부산광역시 사직동',
+          style: TextStyle(
+            color: MColor.kLabel.normal,
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        SizedBox(height: 4),
+        Text(
+          '13˚',
+          style: TextStyle(
+            color: MColor.kLabel.normal,
+            fontSize: 38,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        SizedBox(height: 4),
+        Text(
+          '어제보다 0.9˚↑',
+          style: TextStyle(
+            color: MColor.kLabel.normal,
+            fontSize: 14,
+            fontWeight: FontWeight.w400,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_weather_list.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_weather_list.dart
@@ -1,0 +1,22 @@
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_humidity.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_keyword.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_wind.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionWeatherList extends StatelessWidget {
+  const RainoutPredictionWeatherList({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        RainoutPredictionKeyword(),
+        RainoutPredictionHumidity(),
+        RainoutPredictionWind(),
+      ],
+    );
+  }
+}

--- a/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_wind.dart
+++ b/lib/ui/pages/holder/game_center/rainout_prediction_page/widget/rainout_prediction_wind.dart
@@ -1,0 +1,27 @@
+import 'package:ballkkaye_frontend/_core/style/m_color.dart';
+import 'package:ballkkaye_frontend/_core/style/m_icon.dart';
+import 'package:flutter/material.dart';
+
+class RainoutPredictionWind extends StatelessWidget {
+  const RainoutPredictionWind({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        MIcon.page.rainout.bWind,
+        SizedBox(height: 6),
+        Text(
+          '남서풍 0.4m/s',
+          style: TextStyle(
+            color: MColor.kLabel.normal,
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
- 우천취소예측 화면 구현
- rainout_prediction_body : 바디 컴포넌트 분리
- rainout_prediction_stadium_dropdown : 드롭다운 컴포넌트 분리
- rainout_prediction_card : 그림자가 들어간 카드 컴포넌트 분리
- rainout_prediction_weather_head : 카드 내부 가장 상단에 있는 위치와 날씨정보
- rainout_prediction_weather_list : 카드 내부 중간에 있는 날짜 아이콘 리스트
- rainout_prediction_keyword : weather_list 안의 날씨 키워드 영역
- rainout_prediction_humidity : weather_list 안의 습도 영역
- rainout_prediction_wind : weather_list 안의 바람 영역
- rainout_prediction_rain_value : 강수 영역
- rainout_prediction_rain_per : 강수율 스크롤 영역
- rainout_prediction_rain_per_box : 강수율 각 박스
- rainout_prediction_rainfall : 강수량 스크롤 영역
- rainout_prediction_rainfall_box : 강수량 각 박스
- rainout_prediction_report : 우천예측리포트 영역
- rainout_prediction_report_label : 우천예측 라벨

* 가로 스크롤은 에뮬레이터로 확인할 수 있습니다. 크롬에서는 작동이 안되는 이슈가 있어요.
* 두가지 가로 스크롤이 연동되어 같이 움직이는건 sateful로 변경 뒤 구현할 수 있습니다.