### PR TITLE
마이페이지 서비스/유저카드 이동 라우팅 기능 추가

### DIFF
--- a/lib/ui/pages/mypage/user/update_page/widgets/user_update_body.dart
+++ b/lib/ui/pages/mypage/user/update_page/widgets/user_update_body.dart
@@ -1,12 +1,12 @@
 import 'package:ballkkaye_frontend/_core/style/m_color.dart';
 import 'package:ballkkaye_frontend/_core/style/m_icon.dart';
 import 'package:ballkkaye_frontend/_core/style/m_text.dart';
-import 'package:ballkkaye_frontend/ui/pages/holder/user_match/update_page/widgets/update_select_btn.dart';
 import 'package:ballkkaye_frontend/ui/pages/mypage/user/update_password_page/user_update_password_page.dart';
 import 'package:flutter/material.dart';
 
 import 'user_update_labeled_field.dart';
 import 'user_update_outlinedInput_field.dart';
+import 'user_update_select_btn.dart';
 
 class UserUpdateBody extends StatelessWidget {
   const UserUpdateBody({
@@ -85,7 +85,7 @@ class UserUpdateBody extends StatelessWidget {
                   ),
                   UserUpdateLabeledField(
                     label: '내 응원팀',
-                    child: UpdateSelectBtn(
+                    child: UserUpdateSelectBtn(
                       hintText: '롯데 자이언츠',
                       options: [
                         '롯데 자이언츠',
@@ -104,8 +104,8 @@ class UserUpdateBody extends StatelessWidget {
                       TextButton(
                         onPressed: () {
                           Navigator.push(
-                              context,
-                              MaterialPageRoute(builder: (_) => UserUpdatePasswordPage()),
+                            context,
+                            MaterialPageRoute(builder: (_) => UserUpdatePasswordPage()),
                           );
                         },
                         child: MText.label1_5('비밀번호 변경하기', color: MColor.kLabel.normal),

--- a/lib/ui/pages/mypage/widgets/mypage_service_list.dart
+++ b/lib/ui/pages/mypage/widgets/mypage_service_list.dart
@@ -1,5 +1,14 @@
 import 'package:ballkkaye_frontend/_core/style/m_color.dart';
 import 'package:ballkkaye_frontend/_core/style/m_icon.dart';
+import 'package:ballkkaye_frontend/ui/pages/board/list_page/board_list_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/chat_room/list_page/chat_room_list_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/prediction_page/prediction_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/rainout_prediction_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/ranking_page/ranking_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/today_game_page/today_game_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/user_prediction_page/user_prediction_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/user_match/list_page/list_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/visit_record/list_page/visit_record_list_page.dart';
 import 'package:ballkkaye_frontend/ui/pages/mypage/widgets/mypage_service_item.dart';
 import 'package:flutter/material.dart';
 
@@ -8,58 +17,101 @@ class MypageServiceList extends StatelessWidget {
     super.key,
   });
 
-  final List<Widget> serviceItems = [
-    ServiceItem(
-      icon: MIcon.page.mypage.prediction,
-      label: '승리예측',
-      onTap: () {
-        debugPrint('승리예측 클릭');
-      },
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.rain,
-      label: '우천 취소 예측',
-      onTap: () {},
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.record,
-      label: '나의 승부 예측',
-      onTap: () {},
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.todayGame,
-      label: '오늘의 경기',
-      onTap: () {},
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.record,
-      label: '팀 순위',
-      onTap: () {},
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.match,
-      label: '동행',
-      onTap: () {},
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.chat,
-      label: '채팅',
-      onTap: () {},
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.record,
-      label: '직관기록',
-      onTap: () {},
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.community,
-      label: '커뮤니티',
-      onTap: () {},
-    ),
-  ];
-
   @override
   Widget build(BuildContext context) {
+    final List<Widget> serviceItems = [
+      ServiceItem(
+        icon: MIcon.page.mypage.prediction,
+        label: '승리예측',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => PredictionPage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.rain,
+        label: '우천 취소 예측',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => RainoutPredictionPage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.record,
+        label: '나의 승부 예측',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => UserPredictionPage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.todayGame,
+        label: '오늘의 경기',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => TodayGamePage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.record,
+        label: '팀 순위',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => RankingPage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.match,
+        label: '동행',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => UserMatchListPage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.chat,
+        label: '채팅',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => ChatRoomListPage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.record,
+        label: '직관기록',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => VisitRecordListPage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.community,
+        label: '커뮤니티',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => BoardListPage()),
+          );
+        },
+      ),
+    ];
+
     return Container(
       decoration: BoxDecoration(
           color: MColor.kBackground.normal, borderRadius: BorderRadius.circular(12), boxShadow: MColor.kShadow.normal),

--- a/lib/ui/pages/mypage/widgets/mypage_user_card.dart
+++ b/lib/ui/pages/mypage/widgets/mypage_user_card.dart
@@ -1,5 +1,6 @@
 import 'package:ballkkaye_frontend/_core/style/m_color.dart';
 import 'package:ballkkaye_frontend/_core/style/m_icon.dart';
+import 'package:ballkkaye_frontend/ui/pages/mypage/user/detail_page/user_detail_page.dart';
 import 'package:flutter/material.dart';
 
 class MypageUserCard extends StatelessWidget {
@@ -43,7 +44,12 @@ class MypageUserCard extends StatelessWidget {
               height: 1.2,
             )),
         trailing: Icon(Icons.chevron_right),
-        onTap: () {}, // 프로필 상세 이동
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => UserDetailPage()),
+          );
+        }, // 프로필 상세 이동
       ),
     );
   }


### PR DESCRIPTION
### 작업 개요
- 마이페이지 서비스 목록(ServiceList) 및 유저 카드(UserCard)에서
  각 항목 클릭 시 이동할 수 있도록 라우팅 기능을 추가했습니다.

### 주요 변경사항
• MypageServiceList의 ServiceItem에 Navigator.push 로 이동 로직 적용  
• MypageUserCard 클릭 시 프로필 수정 페이지(UserUpdatePage)로 진입  
• context 참조 에러 방지를 위해 build 메서드 내에서 serviceItems 선언  
• 로그인 화면 등 추가 이동 경로는 추후 보강 예정