### PR TITLE
프로필 수정 이미지 선택 및 미리보기 UI 구현

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.CAMERA" />
+
     <application
         android:label="ballkkaye_frontend"
         android:name="${applicationName}"
@@ -17,12 +21,11 @@
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme" />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
@@ -38,8 +41,8 @@
          In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
     <queries>
         <intent>
-            <action android:name="android.intent.action.PROCESS_TEXT"/>
-            <data android:mimeType="text/plain"/>
+            <action android:name="android.intent.action.PROCESS_TEXT" />
+            <data android:mimeType="text/plain" />
         </intent>
     </queries>
 </manifest>

--- a/lib/ui/pages/mypage/user/detail_page/widgets/user_detail_profile_card.dart
+++ b/lib/ui/pages/mypage/user/detail_page/widgets/user_detail_profile_card.dart
@@ -1,6 +1,8 @@
 import 'package:ballkkaye_frontend/_core/style/m_color.dart';
 import 'package:ballkkaye_frontend/_core/style/m_icon.dart';
 import 'package:ballkkaye_frontend/_core/style/m_text.dart';
+import 'package:ballkkaye_frontend/ui/pages/auth/login_page/login_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/mypage/user/update_page/user_update_page.dart';
 import 'package:flutter/material.dart';
 
 class UserDetailProfileCard extends StatelessWidget {
@@ -64,7 +66,11 @@ class UserDetailProfileCard extends StatelessWidget {
                 ),
                 TextButton(
                   onPressed: () {
-                    // 로그아웃 로직
+                    Navigator.pushAndRemoveUntil(
+                      context,
+                      MaterialPageRoute(builder: (_) => const LoginPage()),
+                      (route) => false,
+                    ); // 로그아웃 로직
                   },
                   style: TextButton.styleFrom(
                       minimumSize: const Size(0, 20),
@@ -84,7 +90,10 @@ class UserDetailProfileCard extends StatelessWidget {
                   backgroundColor: Colors.black,
                 ),
                 onPressed: () {
-                  // 프로필 수정
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => UserUpdatePage()),
+                  );
                 },
                 child: Text(
                   "프로필 수정",

--- a/lib/ui/pages/mypage/user/detail_page/widgets/user_detail_profile_card.dart
+++ b/lib/ui/pages/mypage/user/detail_page/widgets/user_detail_profile_card.dart
@@ -70,7 +70,7 @@ class UserDetailProfileCard extends StatelessWidget {
                       context,
                       MaterialPageRoute(builder: (_) => const LoginPage()),
                       (route) => false,
-                    ); // 로그아웃 로직
+                    ); //로그아웃 로직
                   },
                   style: TextButton.styleFrom(
                       minimumSize: const Size(0, 20),

--- a/lib/ui/pages/mypage/user/update_page/user_update_page.dart
+++ b/lib/ui/pages/mypage/user/update_page/user_update_page.dart
@@ -33,7 +33,10 @@ class UserUpdatePage extends StatelessWidget {
       actions: [
         TextButton(
           onPressed: () {
-            // 수정 로직
+            // 수정 성공 시
+            Navigator.pop(
+              context, /* 필요하다면 수정된 유저정보 */
+            );
           },
           child: MText.label1_5('수정', color: MColor.kLabel.normal),
         ),

--- a/lib/ui/pages/mypage/user/update_page/widgets/user_update_body.dart
+++ b/lib/ui/pages/mypage/user/update_page/widgets/user_update_body.dart
@@ -1,11 +1,11 @@
 import 'package:ballkkaye_frontend/_core/style/m_color.dart';
-import 'package:ballkkaye_frontend/_core/style/m_icon.dart';
 import 'package:ballkkaye_frontend/_core/style/m_text.dart';
 import 'package:ballkkaye_frontend/ui/pages/mypage/user/update_password_page/user_update_password_page.dart';
 import 'package:flutter/material.dart';
 
 import 'user_update_labeled_field.dart';
 import 'user_update_outlinedInput_field.dart';
+import 'user_update_profile_image_picker.dart';
 import 'user_update_select_btn.dart';
 
 class UserUpdateBody extends StatelessWidget {
@@ -38,39 +38,7 @@ class UserUpdateBody extends StatelessWidget {
                         height: 125,
                         child: Padding(
                           padding: const EdgeInsets.only(top: 20, bottom: 20),
-                          child: Stack(
-                            children: [
-                              // 배경 (동그라미 + 이미지 아이콘)
-                              Container(
-                                width: 80,
-                                height: 80,
-                                decoration: BoxDecoration(
-                                  color: Colors.grey.shade200,
-                                  shape: BoxShape.circle,
-                                ),
-                                child: Center(child: MIcon.page.record.image),
-                              ),
-
-                              // 오른쪽 아래 플러스 아이콘
-                              Positioned(
-                                bottom: 0,
-                                right: 0,
-                                child: Container(
-                                  width: 24,
-                                  height: 24,
-                                  decoration: BoxDecoration(
-                                    color: Colors.black,
-                                    shape: BoxShape.circle,
-                                  ),
-                                  child: const Icon(
-                                    Icons.add,
-                                    color: Colors.white,
-                                    size: 16,
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
+                          child: UserUpdateProfileImagePicker(),
                         ),
                       ),
                     ],

--- a/lib/ui/pages/mypage/user/update_page/widgets/user_update_body.dart
+++ b/lib/ui/pages/mypage/user/update_page/widgets/user_update_body.dart
@@ -1,12 +1,12 @@
 import 'package:ballkkaye_frontend/_core/style/m_color.dart';
 import 'package:ballkkaye_frontend/_core/style/m_icon.dart';
 import 'package:ballkkaye_frontend/_core/style/m_text.dart';
-import 'package:ballkkaye_frontend/ui/pages/holder/user_match/update_page/widgets/update_select_btn.dart';
 import 'package:ballkkaye_frontend/ui/pages/mypage/user/update_password_page/user_update_password_page.dart';
 import 'package:flutter/material.dart';
 
 import 'user_update_labeled_field.dart';
 import 'user_update_outlinedInput_field.dart';
+import 'user_update_select_btn.dart';
 
 class UserUpdateBody extends StatelessWidget {
   const UserUpdateBody({
@@ -85,7 +85,7 @@ class UserUpdateBody extends StatelessWidget {
                   ),
                   UserUpdateLabeledField(
                     label: '내 응원팀',
-                    child: UpdateSelectBtn(
+                    child: UserUpdateSelectBtn(
                       hintText: '롯데 자이언츠',
                       options: [
                         '롯데 자이언츠',
@@ -104,8 +104,8 @@ class UserUpdateBody extends StatelessWidget {
                       TextButton(
                         onPressed: () {
                           Navigator.push(
-                              context,
-                              MaterialPageRoute(builder: (_) => UserUpdatePasswordPage()),
+                            context,
+                            MaterialPageRoute(builder: (_) => UserUpdatePasswordPage()),
                           );
                         },
                         child: MText.label1_5('비밀번호 변경하기', color: MColor.kLabel.normal),

--- a/lib/ui/pages/mypage/user/update_page/widgets/user_update_profile_image_picker.dart
+++ b/lib/ui/pages/mypage/user/update_page/widgets/user_update_profile_image_picker.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:ballkkaye_frontend/_core/style/m_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 
@@ -27,7 +28,6 @@ class _UserUpdateProfileImagePickerState extends State<UserUpdateProfileImagePic
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        print('✅ tapped!');
         _pickImage();
       },
       child: Stack(
@@ -48,7 +48,7 @@ class _UserUpdateProfileImagePickerState extends State<UserUpdateProfileImagePic
             ),
             child: _selectedImage == null
                 ? Center(
-                    child: Icon(Icons.image, size: 30, color: Colors.grey),
+                    child: Center(child: MIcon.page.record.image),
                   )
                 : null,
           ),

--- a/lib/ui/pages/mypage/user/update_page/widgets/user_update_profile_image_picker.dart
+++ b/lib/ui/pages/mypage/user/update_page/widgets/user_update_profile_image_picker.dart
@@ -1,0 +1,78 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+class UserUpdateProfileImagePicker extends StatefulWidget {
+  const UserUpdateProfileImagePicker({super.key});
+
+  @override
+  State<UserUpdateProfileImagePicker> createState() => _UserUpdateProfileImagePickerState();
+}
+
+class _UserUpdateProfileImagePickerState extends State<UserUpdateProfileImagePicker> {
+  File? _selectedImage;
+
+  Future<void> _pickImage() async {
+    final picker = ImagePicker();
+    final pickedFile = await picker.pickImage(source: ImageSource.gallery);
+    if (pickedFile != null) {
+      setState(() {
+        _selectedImage = File(pickedFile.path);
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        print('✅ tapped!');
+        _pickImage();
+      },
+      child: Stack(
+        children: [
+          // 배경 (동그라미 + 이미지 아이콘)
+          Container(
+            width: 80,
+            height: 80,
+            decoration: BoxDecoration(
+              color: Colors.grey.shade200,
+              shape: BoxShape.circle,
+              image: _selectedImage != null
+                  ? DecorationImage(
+                      image: FileImage(_selectedImage!),
+                      fit: BoxFit.cover,
+                    )
+                  : null,
+            ),
+            child: _selectedImage == null
+                ? Center(
+                    child: Icon(Icons.image, size: 30, color: Colors.grey),
+                  )
+                : null,
+          ),
+
+          // 오른쪽 아래 플러스 아이콘
+          Positioned(
+            bottom: 0,
+            right: 0,
+            child: Container(
+              width: 24,
+              height: 24,
+              decoration: const BoxDecoration(
+                color: Colors.black,
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(
+                Icons.add,
+                color: Colors.white,
+                size: 16,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/mypage/widgets/mypage_service_list.dart
+++ b/lib/ui/pages/mypage/widgets/mypage_service_list.dart
@@ -1,5 +1,14 @@
 import 'package:ballkkaye_frontend/_core/style/m_color.dart';
 import 'package:ballkkaye_frontend/_core/style/m_icon.dart';
+import 'package:ballkkaye_frontend/ui/pages/board/list_page/board_list_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/chat_room/list_page/chat_room_list_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/prediction_page/prediction_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/rainout_prediction_page/rainout_prediction_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/ranking_page/ranking_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/today_game_page/today_game_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/game_center/user_prediction_page/user_prediction_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/user_match/list_page/list_page.dart';
+import 'package:ballkkaye_frontend/ui/pages/holder/visit_record/list_page/visit_record_list_page.dart';
 import 'package:ballkkaye_frontend/ui/pages/mypage/widgets/mypage_service_item.dart';
 import 'package:flutter/material.dart';
 
@@ -8,58 +17,101 @@ class MypageServiceList extends StatelessWidget {
     super.key,
   });
 
-  final List<Widget> serviceItems = [
-    ServiceItem(
-      icon: MIcon.page.mypage.prediction,
-      label: '승리예측',
-      onTap: () {
-        debugPrint('승리예측 클릭');
-      },
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.rain,
-      label: '우천 취소 예측',
-      onTap: () {},
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.record,
-      label: '나의 승부 예측',
-      onTap: () {},
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.todayGame,
-      label: '오늘의 경기',
-      onTap: () {},
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.record,
-      label: '팀 순위',
-      onTap: () {},
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.match,
-      label: '동행',
-      onTap: () {},
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.chat,
-      label: '채팅',
-      onTap: () {},
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.record,
-      label: '직관기록',
-      onTap: () {},
-    ),
-    ServiceItem(
-      icon: MIcon.page.mypage.community,
-      label: '커뮤니티',
-      onTap: () {},
-    ),
-  ];
-
   @override
   Widget build(BuildContext context) {
+    final List<Widget> serviceItems = [
+      ServiceItem(
+        icon: MIcon.page.mypage.prediction,
+        label: '승리예측',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => PredictionPage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.rain,
+        label: '우천 취소 예측',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => RainoutPredictionPage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.record,
+        label: '나의 승부 예측',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => UserPredictionPage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.todayGame,
+        label: '오늘의 경기',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => TodayGamePage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.record,
+        label: '팀 순위',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => RankingPage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.match,
+        label: '동행',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => UserMatchListPage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.chat,
+        label: '채팅',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => ChatRoomListPage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.record,
+        label: '직관기록',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => VisitRecordListPage()),
+          );
+        },
+      ),
+      ServiceItem(
+        icon: MIcon.page.mypage.community,
+        label: '커뮤니티',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => BoardListPage()),
+          );
+        },
+      ),
+    ];
+
     return Container(
       decoration: BoxDecoration(
           color: MColor.kBackground.normal, borderRadius: BorderRadius.circular(12), boxShadow: MColor.kShadow.normal),

--- a/lib/ui/pages/mypage/widgets/mypage_user_card.dart
+++ b/lib/ui/pages/mypage/widgets/mypage_user_card.dart
@@ -1,5 +1,6 @@
 import 'package:ballkkaye_frontend/_core/style/m_color.dart';
 import 'package:ballkkaye_frontend/_core/style/m_icon.dart';
+import 'package:ballkkaye_frontend/ui/pages/mypage/user/detail_page/user_detail_page.dart';
 import 'package:flutter/material.dart';
 
 class MypageUserCard extends StatelessWidget {
@@ -43,7 +44,12 @@ class MypageUserCard extends StatelessWidget {
               height: 1.2,
             )),
         trailing: Icon(Icons.chevron_right),
-        onTap: () {}, // 프로필 상세 이동
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => UserDetailPage()),
+          );
+        }, // 프로필 상세 이동
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -153,6 +161,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+2"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "8c9250b2bd2d8d4268e39c82543bacbaca0fda7d29e0728c3c4bbb7c820fd711"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+3"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+4"
   fixnum:
     dependency: transitive
     description:
@@ -203,6 +243,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: f948e346c12f8d5480d2825e03de228d0eb8c3a737e4cdaa122267b89c022b5e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.28"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -261,6 +309,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "317a5d961cec5b34e777b9252393f2afbd23084aa6e60fcf601dcf6341b9ebeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+23"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+2"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "34a65f6740df08bbbeb0a1abd8e6d32107941fd4868f67a507b25601651022c9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "1b90ebbd9dcf98fb6c1d01427e49a55bd96b5d67b8c67cf955d60a5de74207c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   intl:
     dependency: "direct main"
     description:
@@ -333,6 +445,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   octo_image:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   fl_chart: ^1.0.0
   url_launcher: ^6.3.1
   carousel_slider: ^5.1.1
+  image_picker: ^1.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 작업 내용
- UserUpdateProfileImagePicker위젯으로 따로 분리
- 사용자 프로필 이미지 선택 기능 추가 (갤러리 연동)
- 선택된 이미지를 로컬에서 미리보기로 표시
- Stack 기반 UI 구성 (placeholder + + 버튼)
- 권한 요청 및 targetSdkVersion 대응
- 실제 이미지 업로드 로직은 추후 서버 연동 예정

AndroidManifest.xml에서 
 uses-permission android:name="android.permission.READ_MEDIA_IMAGES"
uses-permission android:name="android.permission.CAMERA"
사진 카메라 접근권한 허용코드
