### PR TITLE
커뮤니티 게시글 삭제기능

### DIFF
--- a/lib/data/repository/board_repository.dart
+++ b/lib/data/repository/board_repository.dart
@@ -255,4 +255,14 @@ class BoardRepository {
     Logger().d(responseBody);
     return responseBody;
   }
+
+  Future<Map<String, dynamic>> deleteOne(int boardId) async {
+    final responseBody = {
+      "status": 200,
+      "msg": "성공",
+      "body": {"deleteStatus": "삭제됨"}
+    };
+    Logger().d(responseBody);
+    return responseBody;
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,7 +79,7 @@ class MyApp extends StatelessWidget {
         "/game-center/today-game": (context) => const TodayGamePage(),
         "/game-center/user-prediction": (context) => const UserPredictionPage(),
         "/board/list": (context) => const BoardListPage(),
-        "/board/detail": (context) => BoardDetailPage(1), //todo 나중에 리스트에서 받은값 전달하기
+        "/board/detail": (context) => BoardDetailPage(13), //todo 나중에 리스트에서 받은값 전달하기
         "/board/write": (context) => const BoardWritePage(),
         // "/board/update": (context) => BoardUpdatePage(), // 동적데이터 받기 어려워서 MaterialPageRoute 사용
         "/user-match/update": (context) => const UserMatchUpdatePage(),

--- a/lib/ui/pages/board/detail_page/board_detail_board_vm.dart
+++ b/lib/ui/pages/board/detail_page/board_detail_board_vm.dart
@@ -59,6 +59,19 @@ class BoardDetailBoardVM extends AutoDisposeFamilyNotifier<BoardDetailBoardModel
     // 5. pop
     Navigator.pop(mContext);
   }
+
+  Future<void> deleteOne(int boardId) async {
+    Map<String, dynamic> data = await BoardRepository().deleteOne(boardId);
+    if (data["status"] != 200) {
+      ScaffoldMessenger.of(mContext!).showSnackBar(
+        SnackBar(content: Text("게시글 삭제하기 실패 : ${data["msg"]}")),
+      );
+      return;
+    }
+
+    ref.read(boardListBoardProvider.notifier).notifyDeleteOne(boardId);
+    Navigator.pop(mContext);
+  }
 }
 
 class BoardDetailBoardModel {

--- a/lib/ui/pages/board/detail_page/board_detail_page.dart
+++ b/lib/ui/pages/board/detail_page/board_detail_page.dart
@@ -25,7 +25,7 @@ class BoardDetailPage extends ConsumerWidget {
       return Center(child: CircularProgressIndicator());
     } else {
       return Scaffold(
-        appBar: _appbar(context, boardModel),
+        appBar: _appbar(context, boardModel, ref),
         body: BoardDetailBody(
           board: boardModel.board,
           replies: replyModel.replies,
@@ -37,7 +37,8 @@ class BoardDetailPage extends ConsumerWidget {
     }
   }
 
-  AppBar _appbar(BuildContext context, model) {
+  AppBar _appbar(BuildContext context, model, ref) {
+    BoardDetailBoardVM vm = ref.read(boardDetailBoardProvider(boardId).notifier);
     return AppBar(
       centerTitle: true,
       title: MText.h1('커뮤니티', color: MColor.kLabel.normal),
@@ -59,7 +60,9 @@ class BoardDetailPage extends ConsumerWidget {
 
             alertTitle: '게시글 삭제',
             alertContent: '게시글을 삭제하시겠습니까?',
-            onAlertConfirm: () {},
+            onAlertConfirm: () {
+              vm.deleteOne(boardId);
+            },
             // 다이얼로그 닫힌 뒤 동작
             onAlertCancel: () {},
             // 다이얼로그 닫힌 뒤 동작

--- a/lib/ui/pages/board/list_page/board_list_board_vm.dart
+++ b/lib/ui/pages/board/list_page/board_list_board_vm.dart
@@ -7,8 +7,7 @@ import 'package:logger/logger.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
 
 /// 1. 창고 관리자
-final boardListBoardProvider =
-    AutoDisposeNotifierProvider<BoardListBoardVM, BoardListBoardModel?>(() {
+final boardListBoardProvider = AutoDisposeNotifierProvider<BoardListBoardVM, BoardListBoardModel?>(() {
   return BoardListBoardVM();
 });
 
@@ -52,6 +51,14 @@ class BoardListBoardVM extends AutoDisposeNotifier<BoardListBoardModel?> {
     state = state!.copyWith(boards: nextBoards);
   }
 
+  void notifyDeleteOne(int boardId) {
+    BoardListBoardModel model = state!;
+
+    model.boards = model.boards.where((p) => p.boardId != boardId).toList();
+
+    state = state!.copyWith(boards: model.boards);
+  }
+
   Future<void> getList() async {
     BoardListBoardModel prevModel = state!;
     Map<String, dynamic> data = await BoardRepository().getList();
@@ -91,7 +98,7 @@ class BoardListBoardModel {
 
   BoardListBoardModel.fromMap(Map<String, dynamic> data)
       : boards = (data['items'] as List).map((e) => Board.fromMap(e)).toList();
-  
+
   BoardListBoardModel copyWith({
     List<Board>? boards,
   }) {


### PR DESCRIPTION
## 주요 변경 사항
- 상세 페이지 라우팅 시 board 하드코딩 제거Id 하드코딩 제거
  - Navigator.pushNamed를 통해 arguments 전달
  - 상세 페이지에서 ModalRoute로 boardId 수신
- 게시글 삭제 기능 구현
  - BoardRepository.deleteOne() 통해 삭제 응답 처리
  - 삭제 성공 시 boardListProvider 상태에서 해당 게시글 제거
- 삭제 반영 후 Navigator.pop()으로 상세 페이지 닫힘
