### PR TITLE
승부 예측 이미지 비율/정렬 수정 및 UI 안정성 개선 (PR O)

### DIFF
--- a/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_card.dart
+++ b/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_card.dart
@@ -68,7 +68,6 @@ class PredictionCard extends StatelessWidget {
                                     color: MColor.kBackground.normal,
                                     borderRadius: BorderRadius.circular(8),
                                   ),
-                                  // TODO: 나중에 통신 연결 시 null자리에 imageUrl
                                   child: PredictionPlayerImage(predictionGame.homePitcherProfileUrl),
                                 ),
                               ),
@@ -144,7 +143,6 @@ class PredictionCard extends StatelessWidget {
                                     color: MColor.kBackground.normal,
                                     borderRadius: BorderRadius.circular(8),
                                   ),
-                                  // TODO: 나중에 통신 연결 시 null자리에 imageUrl
                                   child: PredictionPlayerImage(predictionGame.awayPitcherProfileUrl),
                                 ),
                               ),

--- a/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_card.dart
+++ b/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_card.dart
@@ -62,10 +62,10 @@ class PredictionCard extends StatelessWidget {
                           children: [
                             Expanded(
                               child: AspectRatio(
-                                aspectRatio: 5 / 7,
+                                aspectRatio: 7 / 7,
                                 child: Container(
                                   decoration: BoxDecoration(
-                                    color: MColor.kFill.normal,
+                                    color: MColor.kBackground.normal,
                                     borderRadius: BorderRadius.circular(8),
                                   ),
                                   // TODO: 나중에 통신 연결 시 null자리에 imageUrl
@@ -138,10 +138,10 @@ class PredictionCard extends StatelessWidget {
                           children: [
                             Expanded(
                               child: AspectRatio(
-                                aspectRatio: 5 / 7,
+                                aspectRatio: 7 / 7,
                                 child: Container(
                                   decoration: BoxDecoration(
-                                    color: MColor.kFill.alternative,
+                                    color: MColor.kBackground.normal,
                                     borderRadius: BorderRadius.circular(8),
                                   ),
                                   // TODO: 나중에 통신 연결 시 null자리에 imageUrl

--- a/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_card.dart
+++ b/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_card.dart
@@ -69,7 +69,7 @@ class PredictionCard extends StatelessWidget {
                                     borderRadius: BorderRadius.circular(8),
                                   ),
                                   // TODO: 나중에 통신 연결 시 null자리에 imageUrl
-                                  child: PredictionPlayerImage(null),
+                                  child: PredictionPlayerImage(predictionGame.homePitcherProfileUrl),
                                 ),
                               ),
                             ),
@@ -141,11 +141,11 @@ class PredictionCard extends StatelessWidget {
                                 aspectRatio: 5 / 7,
                                 child: Container(
                                   decoration: BoxDecoration(
-                                    color: MColor.kFill.normal,
+                                    color: MColor.kFill.alternative,
                                     borderRadius: BorderRadius.circular(8),
                                   ),
                                   // TODO: 나중에 통신 연결 시 null자리에 imageUrl
-                                  child: PredictionPlayerImage(null),
+                                  child: PredictionPlayerImage(predictionGame.awayPitcherProfileUrl),
                                 ),
                               ),
                             ),

--- a/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_player_image.dart
+++ b/lib/ui/pages/holder/game_center/prediction_page/widget/prediction_player_image.dart
@@ -8,9 +8,14 @@ Widget PredictionPlayerImage(String? imageUrl) {
       child: MText.normal5_6('이미지 준비중', color: MColor.kLabel.alternative),
     );
   } else {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(8),
-      child: Image.network(imageUrl, fit: BoxFit.cover),
+    return Center(
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(8),
+        child: Image.network(
+          imageUrl,
+          fit: BoxFit.scaleDown,
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
### 변경 내용
- `AspectRatio` 비율을 `5/7` → `7/7`(정사각형)으로 수정하여 박스 크기 비대칭 문제 해결
- 선수 이미지 비어있을 경우 예외 처리를 위한 `null` → 실제 imageUrl 연결로 변경
- `Image.network`의 `fit`을 `BoxFit.cover` → `BoxFit.scaleDown`으로 교체하여 이미지 과도한 확대 방지
- 이미지가 잘리는 현상을 방지하고 중앙 정렬을 위한 `Center` 래퍼 추가

### 이유
- 오른쪽 이미지 박스가 왼쪽으로 쏠려 보이는 UI 문제 해결
- 이미지가 너무 확대되어 얼굴이 잘리는 문제를 개선
- 사용자 경험을 위한 시각적 안정성 및 일관성 확보
